### PR TITLE
feat: update release script to build for m1 macs

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -2,8 +2,12 @@
 # this script should be replaces by github actions
 
 npm version patch
-yarn tauri build
+yarn tauri build --target aarch64-apple-darwin
+yarn tauri build --target x86_64-apple-darwin
 version=$(grep version package.json | awk -F \" '{print $4}')
 
 echo "releasing version: $version"
-gh release create $version "src-tauri/target/release/bundle/dmg/Kube Knots_${version}_x64.dmg" --generate-notes
+gh release create $version \
+ "src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/kube-knots_${version}_x64.dmg"  \ 
+ "src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/kube-knots_${version}_aarch64.dmgg"  \ 
+ --generate-notes

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1632,6 +1632,7 @@ version = "0.0.0"
 dependencies = [
  "k8s-openapi",
  "kube",
+ "openssl",
  "serde",
  "serde_json",
  "tauri",
@@ -2083,6 +2084,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.24.0+1.1.1s"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3498f259dab01178c6228c6b00dcef0ed2a2d5e20d648c017861227773ea4abd"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2091,6 +2101,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,6 +19,7 @@ serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "1.2", features = ["api-all"] }
 kube = { version = "0.78.0", features = ["runtime", "derive"] }
 k8s-openapi = { version = "0.17.0", features = ["v1_26"] }
+openssl = { version = "0.10.35", features = ["vendored"] }
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -6,7 +6,7 @@
     "distDir": "../dist"
   },
   "package": {
-    "productName": "Kube Knots",
+    "productName": "kube-knots",
     "version": "../package.json"
   },
   "tauri": {


### PR DESCRIPTION
using the sample here https://github.com/dragonflyoss/image-service/commit/81e3ce530963cc86f0ab0d1c8abbcbd6627c89d6

to fix the OpenSSL build issue when targeting M1 macs