### PR TITLE
chore: update release workflow to run on tags with v prefix

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - "0.*"
+      - "v0.*"
 
 jobs:
   create-release:


### PR DESCRIPTION
since npm version patch auto adds the `v` 