### PR TITLE
code-split

### DIFF
--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,16 +1,43 @@
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-import { Outlet, ReactRouter, RootRoute, Route } from "@tanstack/react-router";
+import { lazy, Outlet, ReactRouter, RootRoute, Route } from "@tanstack/react-router";
 
 import { AppProviders } from "./app-providers";
 import { Layout } from "./layout";
-import { Ingresses } from "./networking/ingresses";
-import { Services } from "./networking/services";
-import { CronJobs } from "./workloads/cron-jobs";
-import { Deployments } from "./workloads/deployments";
-import { Jobs } from "./workloads/jobs";
-import { Pods } from "./workloads/pods";
-import { ReplicaSets } from "./workloads/replica-sets";
-import { StatefulSets } from "./workloads/stateful-sets";
+
+// import { Ingresses } from "./networking/ingresses";
+
+// import { Services } from "./networking/services";
+
+// import { CronJobs } from "./workloads/cron-jobs";
+
+// import { Deployments } from "./workloads/deployments";
+
+// import { Jobs } from "./workloads/jobs";
+
+// import { Pods } from "./workloads/pods";
+// import { ReplicaSets } from "./workloads/replica-sets";
+// import { StatefulSets } from "./workloads/stateful-sets";
+
+const Ingresses = lazy(() =>
+  import("./networking/ingresses").then((module) => ({ default: module.Ingresses }))
+);
+const Services = lazy(() =>
+  import("./networking/services").then((module) => ({ default: module.Services }))
+);
+const CronJobs = lazy(() =>
+  import("./workloads/cron-jobs").then((module) => ({ default: module.CronJobs }))
+);
+const Deployments = lazy(() =>
+  import("./workloads/deployments").then((module) => ({ default: module.Deployments }))
+);
+const Jobs = lazy(() => import("./workloads/jobs").then((module) => ({ default: module.Jobs })));
+const Pods = lazy(() => import("./workloads/pods").then((module) => ({ default: module.Pods })));
+const ReplicaSets = lazy(() =>
+  import("./workloads/replica-sets").then((module) => ({ default: module.ReplicaSets }))
+);
+const StatefulSets = lazy(() =>
+  import("./workloads/stateful-sets").then((module) => ({ default: module.StatefulSets }))
+);
 
 const rootRoute = new RootRoute({
   component: () => (

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,9 @@
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import { defineConfig, splitVendorChunkPlugin } from "vite";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), splitVendorChunkPlugin()],
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
   // prevent vite from obscuring rust errors


### PR DESCRIPTION
to improve intiial load time. one issue is still 

```
dist/assets/vendor-c4877e65.js                302.21 kB │ gzip: 91.47 kB
```

which includes 
- react-dom
- @tanstack/query and router
- headlessui

need to figure out a way to split the vendor bundle 