### PR TITLE
feat: support switch context - part 3

### DIFF
--- a/src/core/contexts.tsx
+++ b/src/core/contexts.tsx
@@ -1,10 +1,60 @@
+import { Combobox } from "@headlessui/react";
+import { CheckIcon, ChevronUpDownIcon } from "@heroicons/react/20/solid";
+import { useState } from "react";
+
 import { useCurrentContext } from "../providers/current-context-provider";
 
-export function Contexts() {
-  const { currentContext } = useCurrentContext();
+// TODO: figure out better UX for picking context.
+// this is copied from namespace selector and didn't refactor it to be more generic
+// since it's not clear what the UX should be for
+// possible option is putting context in the settings modal?
+export function ContextSelect() {
+  const [query, setQuery] = useState("");
+  const { currentContext, changeCurrentContext, availableContexts } = useCurrentContext();
+
+  const filteredContexts = availableContexts.filter((context) => {
+    return context.name.toLowerCase().includes(query.toLowerCase());
+  });
+
   return (
-    <div className="flex">
-      <div>Current Context: {currentContext}</div>
-    </div>
+    <Combobox as="div" value={currentContext} onChange={changeCurrentContext}>
+      <div className="relative mt-1">
+        <Combobox.Input
+          className="w-full rounded-md border border-gray-300 bg-white py-2 pl-3 pr-10 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500 dark:border-gray-500 dark:bg-gray-800 dark:text-gray-100"
+          onChange={(event) => setQuery(event.target.value)}
+        />
+        <Combobox.Button className="absolute inset-y-0 right-0 flex items-center rounded-r-md px-2 focus:outline-none">
+          <ChevronUpDownIcon className="h-5 w-5 text-gray-400" aria-hidden="true" />
+        </Combobox.Button>
+
+        {filteredContexts.length > 0 && (
+          <Combobox.Options className="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black/5 focus:outline-none dark:bg-gray-900">
+            {filteredContexts.map((context) => (
+              <Combobox.Option
+                key={context.name}
+                value={context.name}
+                className={({ active }) =>
+                  `relative cursor-default select-none py-2 pl-3 pr-9 text-gray-900 dark:text-gray-100 bg-gray-100 dark:bg-gray-800 ${
+                    active ? "bg-gray-200 dark:bg-gray-700" : ""
+                  }`
+                }
+              >
+                {({ selected }) => (
+                  <>
+                    <span className={`block cursor-pointer truncate`}>{context.name}</span>
+
+                    {selected && (
+                      <span className="absolute inset-y-0 right-0 flex items-center pr-4 text-slate-600 dark:text-slate-300">
+                        <CheckIcon className="h-5 w-5" aria-hidden="true" />
+                      </span>
+                    )}
+                  </>
+                )}
+              </Combobox.Option>
+            ))}
+          </Combobox.Options>
+        )}
+      </div>
+    </Combobox>
   );
 }

--- a/src/hooks/use-resource-list.ts
+++ b/src/hooks/use-resource-list.ts
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { invoke } from "@tauri-apps/api";
 
 import { useCurrentNamespace } from "../namespaces/namespaces";
+import { useCurrentContext } from "../providers/current-context-provider";
 
 type Commands =
   | "get_cron_jobs"
@@ -19,10 +20,11 @@ type Commands =
 
 export function useResourceList<T>(command: Commands) {
   const { namespace } = useCurrentNamespace();
+  const { currentContext } = useCurrentContext();
   const result = useQuery(
     [command, namespace],
     () => {
-      return invoke<{ items: T[] }>(command, { namespace });
+      return invoke<{ items: T[] }>(command, { namespace, context: currentContext });
     },
     // TODO: maybe make this configurable?
     { refetchInterval: 2000 }

--- a/src/hooks/use-resource.ts
+++ b/src/hooks/use-resource.ts
@@ -2,15 +2,17 @@ import { useQuery } from "@tanstack/react-query";
 import { invoke } from "@tauri-apps/api";
 
 import { useCurrentNamespace } from "../namespaces/namespaces";
+import { useCurrentContext } from "../providers/current-context-provider";
 
 type Commands = "get_config";
 
 export function useResource<T>(command: Commands) {
   const { namespace } = useCurrentNamespace();
+  const { currentContext } = useCurrentContext();
   const result = useQuery(
     [command, namespace],
     () => {
-      return invoke<T>(command, { namespace });
+      return invoke<T>(command, { namespace, context: currentContext });
     },
     // TODO: maybe make this configurable?
     { refetchInterval: 2000 }

--- a/src/layout.tsx
+++ b/src/layout.tsx
@@ -3,7 +3,7 @@ import { DocumentMagnifyingGlassIcon } from "@heroicons/react/24/outline";
 import { Link } from "@tanstack/react-router";
 import { lazy, Suspense, useState, type PropsWithChildren } from "react";
 
-import { Contexts } from "./core/contexts";
+import { ContextSelect } from "./core/contexts";
 import { NamespaceSelect } from "./namespaces/namespace-select";
 import { clusterRoutes, networkingRoutes, workloadsRoutes } from "./router";
 
@@ -53,7 +53,7 @@ export function Layout({ children }: PropsWithChildren) {
           <NamespaceSelect />
 
           {/* TODO: figure out where to put context info */}
-          <Contexts />
+          <ContextSelect />
 
           <Cog8ToothIcon
             className="h-6 w-6 cursor-pointer fill-gray-600 hover:fill-gray-800 dark:fill-gray-400 dark:hover:fill-gray-200"


### PR DESCRIPTION
just added a select dropdown for now. still need to see what make sense on how selectors are picks

 a few options 

- put the selector in the settings modal (con: a few more clicks to switch)
- create a button group for each context and allow one click switch. 
- keep it as is in a separate selector near namespace selector. 