### PR TITLE
fix: show loading instead of 404 when a query is initialized

### DIFF
--- a/src/components/query-wrapper.tsx
+++ b/src/components/query-wrapper.tsx
@@ -24,7 +24,7 @@ function WrapperContent({ title, subtitle, action }: WrapperContentProps) {
 
 export function QueryWrapper({ query, children }: QueryWrapperProps) {
   // TODO: improve the UI for these states
-  if (query.isLoading) {
+  if (query.isLoading || query.isFetching) {
     return <WrapperContent title="Loading..." subtitle="..." />;
   }
 


### PR DESCRIPTION
since we populate query with default data, the query initially show up as successful without any data so we see a flash of 404 first. this only happens we the query runs the first time. 