### PR TITLE
Revert "fix: show loading instead of 404 when a query is initialized"

### DIFF
--- a/src/components/query-wrapper.tsx
+++ b/src/components/query-wrapper.tsx
@@ -24,7 +24,7 @@ function WrapperContent({ title, subtitle, action }: WrapperContentProps) {
 
 export function QueryWrapper({ query, children }: QueryWrapperProps) {
   // TODO: improve the UI for these states
-  if (query.isLoading || query.isFetching) {
+  if (query.isLoading) {
     return <WrapperContent title="Loading..." subtitle="..." />;
   }
 


### PR DESCRIPTION
Reverts davidhu2000/kube-knots#176

this caused a different issue of 404 flashing given the query refetches every X seconds