### PR TITLE
fix: update default toast time to from 5s to 3s

### DIFF
--- a/app/kube-knots/src/layout.tsx
+++ b/app/kube-knots/src/layout.tsx
@@ -134,7 +134,7 @@ export function Layout({ children }: PropsWithChildren) {
       <ToastContainer
         theme={themeToUse}
         position="bottom-right"
-        autoClose={5000}
+        autoClose={3000}
         closeOnClick
         pauseOnFocusLoss
         draggable


### PR DESCRIPTION
5s is a bit too long. plus you can hover on the toast to pause, so 3s should be plenty

possibly make this configurable by adding another context provider