### PR TITLE
fix: hide update button whenever no updates are available

### DIFF
--- a/app/kube-knots/src/settings/update-button.tsx
+++ b/app/kube-knots/src/settings/update-button.tsx
@@ -55,7 +55,7 @@ export function UpdateButton() {
   return (
     <Transition
       as={Fragment}
-      show={!updateAvailableQuery.isLoading}
+      show={!!updateAvailableQuery.data?.shouldUpdate}
       enter="transform transition duration-[400ms]"
       enterFrom="opacity-0 scale-50"
       enterTo="opacity-100 scale-100"


### PR DESCRIPTION
## Description

the bug was related to the update button showing based on available update query status, and not based on the result of the query. 

## Testing

open the app on current version: see no button

rebuilt app in 0.0.30, see update button

## Screenshots

N/A

## Related Issues

N/A

## Additional Notes

