### PR TITLE
fix: job table header schedule to show as `Image`

### DIFF
--- a/app/kube-knots/src/workloads/jobs.tsx
+++ b/app/kube-knots/src/workloads/jobs.tsx
@@ -9,7 +9,7 @@ export function Jobs() {
   return (
     <ResourceTable<V1Job>
       command="get_jobs"
-      headers={["Name", "Schedule", "Last Run"]}
+      headers={["Name", "Image", "Last Run"]}
       actions={["edit", "delete"]}
       renderData={(item) => {
         return (


### PR DESCRIPTION
## Description

it was a copy/paste mistake, that column is the image name. 

## Testing

<!-- Please describe the testing that was performed to validate these changes -->

## Screenshots

<!-- Please provide any relevant screenshots or visual aids to help reviewers understand the changes -->

## Related Issues

<!-- Please list any related issues or pull requests -->

## Additional Notes

<!-- Please provide any additional information that may be helpful, such as performance improvements, tradeoffs, or design decisions -->
