### PR TITLE
fix: reduce update check frequency to only check on window focus

### DIFF
--- a/app/kube-knots/src/settings/update-button.tsx
+++ b/app/kube-knots/src/settings/update-button.tsx
@@ -15,7 +15,10 @@ async function update() {
 }
 
 export function UpdateButton() {
-  const updateAvailableQuery = useQuery(["check-update"], checkUpdate);
+  const updateAvailableQuery = useQuery(["check-update"], checkUpdate, {
+    refetchInterval: false,
+    refetchOnWindowFocus: true,
+  });
 
   const updateMutation = useMutation({
     mutationFn: () => {


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request -->

we are checking whether update exist like we do with other kubernetes queries. which is unnecessary and adds unneeded logs, so we going to check update when the window focuses. 

## Testing

<!-- Please describe the testing that was performed to validate these changes -->

## Screenshots

<!-- Please provide any relevant screenshots or visual aids to help reviewers understand the changes -->

## Related Issues

<!-- Please list any related issues or pull requests -->

## Additional Notes

<!-- Please provide any additional information that may be helpful, such as performance improvements, tradeoffs, or design decisions -->
