### PR TITLE
fix: missing executable in path on macos/linux

### DIFF
--- a/app/kube-knots/src-tauri/Cargo.lock
+++ b/app/kube-knots/src-tauri/Cargo.lock
@@ -60,6 +60,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
 name = "async-trait"
 version = "0.1.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,6 +811,15 @@ dependencies = [
  "libc",
  "redox_syscall",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "fix-path-env"
+version = "0.0.0"
+source = "git+https://github.com/tauri-apps/fix-path-env-rs?branch=dev#6c63c49e29e670343b71fee455e1a6c9145f4a8e"
+dependencies = [
+ "strip-ansi-escapes",
+ "thiserror",
 ]
 
 [[package]]
@@ -1699,6 +1714,7 @@ dependencies = [
 name = "kube-knots"
 version = "0.0.0"
 dependencies = [
+ "fix-path-env",
  "k8s-openapi",
  "kube",
  "log",
@@ -3163,6 +3179,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "011cbb39cf7c1f62871aea3cc46e5817b0937b49e9447370c93cacbe93a766d8"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3895,6 +3920,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3948,6 +3979,27 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "vte"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
+dependencies = [
+ "arrayvec",
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "walkdir"

--- a/app/kube-knots/src-tauri/Cargo.toml
+++ b/app/kube-knots/src-tauri/Cargo.toml
@@ -22,6 +22,7 @@ k8s-openapi = { version = "0.17.0", features = ["v1_26"] }
 openssl = { version = "0.10.47", features = ["vendored"] }
 tauri-plugin-log = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "dev" }
 log = "0.4"
+fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs", tag = "fix-path-env-v0.1.0" }
 
 [features]
 # by default Tauri runs in production mode

--- a/app/kube-knots/src-tauri/Cargo.toml
+++ b/app/kube-knots/src-tauri/Cargo.toml
@@ -22,7 +22,7 @@ k8s-openapi = { version = "0.17.0", features = ["v1_26"] }
 openssl = { version = "0.10.47", features = ["vendored"] }
 tauri-plugin-log = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "dev" }
 log = "0.4"
-fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs", tag = "fix-path-env-v0.1.0" }
+fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs", branch = "dev" }
 
 [features]
 # by default Tauri runs in production mode

--- a/app/kube-knots/src-tauri/src/main.rs
+++ b/app/kube-knots/src-tauri/src/main.rs
@@ -3,6 +3,7 @@
     windows_subsystem = "windows"
 )]
 
+use log::error;
 use tauri_plugin_log::LogTarget;
 
 mod internal;
@@ -14,7 +15,11 @@ pub mod networking;
 pub mod workloads;
 
 fn main() {
-    fix_path_env::fix();
+    let fix_result = fix_path_env::fix();
+    if let Err(e) = fix_result {
+        error!("Error while fixing PATH: {}", e);
+    }
+
     tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![
             // events

--- a/app/kube-knots/src-tauri/src/main.rs
+++ b/app/kube-knots/src-tauri/src/main.rs
@@ -14,6 +14,7 @@ pub mod networking;
 pub mod workloads;
 
 fn main() {
+    fix_path_env::fix();
     tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![
             // events


### PR DESCRIPTION
## Description

Fix an issue where we get an error like `missing executable in path`. this is because 

> GUI apps on macOS and Linux do not inherit the $PATH from your shell dotfiles (.bashrc, .bash_profile, .zshrc, etc). Check out Tauri's [fix-path-env-rs](https://github.com/tauri-apps/fix-path-env-rs) crate to fix this issue.

## Testing

make sure everything still works, we won't know for sure this works until we get a prod build release and test it, this seems more an issue with gcloud than AWS

## Screenshots

<!-- Please provide any relevant screenshots or visual aids to help reviewers understand the changes -->

## Related Issues

<!-- Please list any related issues or pull requests -->

## Additional Notes

<!-- Please provide any additional information that may be helpful, such as performance improvements, tradeoffs, or design decisions -->
