### PR TITLE
chore: fix release workflow for macos to not run windows/linux built

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -98,7 +98,7 @@ jobs:
 
       - name: release for windows/linux builds
         uses: tauri-apps/tauri-action@v0
-        if: startsWith(matrix.platform, 'macos') != 'true'
+        if: startsWith(matrix.platform, 'windows') || startsWith(matrix.platform, 'ubuntu')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request -->

## Testing

<!-- Please describe the testing that was performed to validate these changes -->

## Screenshots

<!-- Please provide any relevant screenshots or visual aids to help reviewers understand the changes -->

## Related Issues

<!-- Please list any related issues or pull requests -->

## Additional Notes

<!-- Please provide any additional information that may be helpful, such as performance improvements, tradeoffs, or design decisions -->
