### PR TITLE
fix: fix duplicate key console warning on bar charts

### DIFF
--- a/app/kube-knots/src/root-view/bar-chart.tsx
+++ b/app/kube-knots/src/root-view/bar-chart.tsx
@@ -19,17 +19,17 @@ export function BarChart({ data, barWidth }: BarChartProps) {
   return (
     <div className="flex">
       <div className="mr-2 flex flex-col justify-between text-sm">
-        {labels.map((label) => (
-          <div key={label} className="my-1">
+        {labels.map((label, idx) => (
+          <div key={`${label}-${idx}`} className="my-1">
             {label}
           </div>
         ))}
       </div>
 
       <div className="flex flex-col justify-between text-sm">
-        {values.map((value) => (
+        {values.map((value, idx) => (
           <div
-            key={value}
+            key={`${value}-${idx}`}
             style={{ width: barWidth * (value / maxValue) }}
             className="my-1 rounded-md border bg-green-600 px-2 text-gray-200"
           >


### PR DESCRIPTION
## Description

this happens when we have the same label / same values for those labels, like both pod status has the same number of pods 

## Testing

<!-- Please describe the testing that was performed to validate these changes -->

## Screenshots

<!-- Please provide any relevant screenshots or visual aids to help reviewers understand the changes -->

## Related Issues

<!-- Please list any related issues or pull requests -->

## Additional Notes

<!-- Please provide any additional information that may be helpful, such as performance improvements, tradeoffs, or design decisions -->
