### PR TITLE
docs: add docs on app labeled as damaged on apple silicon 

### DIFF
--- a/app/docs/docs/installation/01-macos.md
+++ b/app/docs/docs/installation/01-macos.md
@@ -20,16 +20,22 @@ Click "Open" and the app will open.
 
 ## Apple Silicon Build Error
 
-If you are using an Apple Silicon Mac, you will see an error when you try to open the app:
+If you are using an Apple Silicon Mac, you may see an error when you try to open the app:
 
-> Kube Knots is damaged and can't be opened. You should move it to the Trash.
+> "Kube Knots" is damaged and can't be opened. You should move it to the Trash.
 
-This is because the app is not signed by Apple. (Again, for now at least). See the [tauri issue](https://github.com/tauri-apps/tauri/issues/5778) for more details.
+This is because the app is not signed by Apple. (Again, for now at least) and apple security setting quarantines the app. See the [tauri issue](https://github.com/tauri-apps/tauri/issues/5778) for more details.
 
 To get around this, we can use the `xattr` command to remove the quarantine attribute from the app.
 
 ```bash
-xattr -rc /Applications/Kube\ Knots.app
+xattr -r -d com.apple.quarantine /Applications/Kube\ Knots.app
 ```
 
 Then you can open the app.
+
+Try the following command if you still see the error:
+
+```bash
+xattr -rc /Applications/Kube\ Knots.app
+```

--- a/app/docs/docs/installation/01-macos.md
+++ b/app/docs/docs/installation/01-macos.md
@@ -17,3 +17,19 @@ To get around this, right click on the app and click "Open". You will see a dial
 ![App Open Warning](./img/macos-second-open-warning.png)
 
 Click "Open" and the app will open.
+
+## Apple Silicon Build Error
+
+If you are using an Apple Silicon Mac, you will see an error when you try to open the app:
+
+> Kube Knots is damaged and can't be opened. You should move it to the Trash.
+
+This is because the app is not signed by Apple. (Again, for now at least). See the [tauri issue](https://github.com/tauri-apps/tauri/issues/5778) for more details.
+
+To get around this, we can use the `xattr` command to remove the quarantine attribute from the app.
+
+```bash
+xattr -rc /Applications/Kube\ Knots.app
+```
+
+Then you can open the app.


### PR DESCRIPTION
## Description

see issue https://github.com/tauri-apps/tauri/issues/5778

TLDR - the app need to be signed by apple for the error to go away. This doc adds an workaround for the time being. 

## Testing

<!-- Please describe the testing that was performed to validate these changes -->

## Screenshots

<!-- Please provide any relevant screenshots or visual aids to help reviewers understand the changes -->

## Related Issues

<!-- Please list any related issues or pull requests -->

## Additional Notes

<!-- Please provide any additional information that may be helpful, such as performance improvements, tradeoffs, or design decisions -->
