### PR TITLE
docs: remove footer theme so it toggles with the theme

### DIFF
--- a/app/docs/docusaurus.config.js
+++ b/app/docs/docusaurus.config.js
@@ -90,7 +90,6 @@ const config = {
         ],
       },
       footer: {
-        style: "dark",
         links: [
           {
             label: "Docs",


### PR DESCRIPTION
## Description

the config lock the footer as dark. removing it means we can toggle the footer theme based on site theme

## Testing

<!-- Please describe the testing that was performed to validate these changes -->

## Screenshots

<!-- Please provide any relevant screenshots or visual aids to help reviewers understand the changes -->

## Related Issues

<!-- Please list any related issues or pull requests -->

## Additional Notes

<!-- Please provide any additional information that may be helpful, such as performance improvements, tradeoffs, or design decisions -->
