### PR TITLE
feat: implement basic telemetry using umami and add custom event to track app version

### DIFF
--- a/app/docs/docs/telemetry.md
+++ b/app/docs/docs/telemetry.md
@@ -1,0 +1,41 @@
+---
+sidebar_position: 5
+---
+
+# Telemetry
+
+This app collect some basic information about your app usage. [umami](https://umami.is/) is used, as it is open source and privacy-focused. From their FAQ regarding GDPR compliance.
+
+> Yes, Umami does not collect any personally identifiable information and anonymizes all data collected. Users cannot be identified and are never tracked across websites.
+
+You can view the data [here](https://analytics.umami.is/share/GMYNZUUE64wQhw3C/kube-knots)
+
+The payload is a based64 encoded JSON object with the following data:
+
+```json
+{
+  "alg":"HS256",
+  "typ":"JWT"
+}
+{
+  "id":"uuid",
+  "websiteId":"a160693a-4f3d-44cd-8d68-eeb87dd8bc4a",
+  "hostname":"localhost",
+  "browser":"ios-webview",
+  "os":"Mac OS",
+  "device":"laptop",
+  "screen":"1440x900",
+  "language":"en-US",
+  "country":"US",
+  "iat":1000000000
+}
+```
+
+The custom metric collected at the moment is the application version running.
+
+You can view the code in [`app/kube-knots/src/telemetry.ts`](https://github.com/davidhu2000/kube-knots/blob/main/app/kube-knots/src/telemetry.ts).
+
+```ts
+const appVersion = await getVersion();
+window.umami(`v${appVersion}`);
+```

--- a/app/kube-knots/index.html
+++ b/app/kube-knots/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kube Knots</title>
+    <script async defer src="https://analytics.umami.is/script.js" data-website-id="a160693a-4f3d-44cd-8d68-eeb87dd8bc4a"></script>
   </head>
 
   <body class="h-full bg-gray-100 dark:bg-gray-800 dark:text-gray-100">

--- a/app/kube-knots/src/app.tsx
+++ b/app/kube-knots/src/app.tsx
@@ -2,8 +2,11 @@ import { RouterProvider } from "@tanstack/react-router";
 
 import { AppProviders } from "./app-providers";
 import { router } from "./router";
+import { useTelemetry } from "./telemetry";
 
 export function App() {
+  useTelemetry();
+
   return (
     <AppProviders>
       <RouterProvider router={router} />

--- a/app/kube-knots/src/telemetry.ts
+++ b/app/kube-knots/src/telemetry.ts
@@ -1,0 +1,19 @@
+import { getVersion } from "@tauri-apps/api/app";
+import { useEffect } from "react";
+
+declare global {
+  interface Window {
+    umami: (event: string) => void;
+  }
+}
+
+async function trackAppVersion() {
+  const appVersion = await getVersion();
+  window.umami(`v${appVersion}`);
+}
+
+export function useTelemetry() {
+  useEffect(() => {
+    trackAppVersion();
+  }, []);
+}


### PR DESCRIPTION
## Description

see the page live https://analytics.umami.is/share/GMYNZUUE64wQhw3C/kube-knots

data collected is written in the docs. 

main usage is figuring out what app versions are running to understand update cycles. currently using umami cloud beta to see if this solution works well. Depending on the cost after beta, we may either do self-hosted or pay for the version. or look for alternatives 

## Testing

see live page

## Screenshots

<img width="1196" alt="Screen Shot 2023-03-24 at 8 42 54 AM" src="https://user-images.githubusercontent.com/15827041/227573407-cc955acf-b8b1-4000-9098-07cb6262447b.png">


## Related Issues

N/A

## Additional Notes

<!-- Please provide any additional information that may be helpful, such as performance improvements, tradeoffs, or design decisions -->
