### PR TITLE
docs: update installation doc title

### DIFF
--- a/app/docs/docs/installation/01-macos.md
+++ b/app/docs/docs/installation/01-macos.md
@@ -1,4 +1,4 @@
-# macOS
+# macOS Installation
 
 Download the `.dmg` file from the [Downloads](/downloads) page. And double click the downloaded file to open the Disk Image.
 

--- a/app/docs/docs/installation/02-linux.md
+++ b/app/docs/docs/installation/02-linux.md
@@ -1,4 +1,4 @@
-# Linux
+# Linux Installation
 
 The app bundle is built using ubuntu 20.04, so it should work on any newer distributions. See tauri [docs](https://tauri.app/v1/guides/building/linux#limitations) for potential issues with running on older distributions.
 

--- a/app/docs/docs/installation/03-windows.md
+++ b/app/docs/docs/installation/03-windows.md
@@ -1,4 +1,4 @@
-# Windows
+# Windows Installation
 
 After downloading the latest version of the windows `.msi` file. Double click the file to start the installation process.
 


### PR DESCRIPTION
## Description

currently it shows as `macOS | Kube Knots`, just updating so it show up as `macOS Installation | Kube Knots` 

## Testing

<!-- Please describe the testing that was performed to validate these changes -->

## Screenshots

<!-- Please provide any relevant screenshots or visual aids to help reviewers understand the changes -->

## Related Issues

<!-- Please list any related issues or pull requests -->

## Additional Notes

<!-- Please provide any additional information that may be helpful, such as performance improvements, tradeoffs, or design decisions -->
