### PR TITLE
chore: optimize query-wrapper-rerender 

### DIFF
--- a/app/kube-knots/src/clusters/nodes.tsx
+++ b/app/kube-knots/src/clusters/nodes.tsx
@@ -46,7 +46,13 @@ export function Nodes() {
   >();
 
   return (
-    <QueryWrapper query={nodeQuery}>
+    <QueryWrapper
+      queryIsSuccess={nodeQuery.isSuccess}
+      queryIsLoading={nodeQuery.isLoading}
+      queryIsError={nodeQuery.isError}
+      queryError={nodeQuery.error}
+      queryDataLength={nodeQuery.data?.items.length || 0}
+    >
       <Table>
         <TableHeader headers={["Name", "CPU", "Memory", "Status", "Pods", "Created", ""]} />
         <TableBody>

--- a/app/kube-knots/src/components/base/table.tsx
+++ b/app/kube-knots/src/components/base/table.tsx
@@ -1,12 +1,12 @@
 import { memo } from "react";
 
-export function Table({ children }: { children: React.ReactNode }) {
+export const Table = memo(function Table({ children }: { children: React.ReactNode }) {
   return (
     <table className="min-w-full select-text divide-y divide-gray-300 rounded-md border-2 border-solid dark:divide-gray-600 dark:border-gray-700">
       {children}
     </table>
   );
-}
+});
 
 export const TableHeader = memo(function TableHeader({ headers }: { headers: string[] }) {
   return (
@@ -26,13 +26,13 @@ export const TableHeader = memo(function TableHeader({ headers }: { headers: str
   );
 });
 
-export function TableBody({ children }: { children: React.ReactNode }) {
+export const TableBody = memo(function TableBody({ children }: { children: React.ReactNode }) {
   return (
     <tbody className="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-gray-800">
       {children}
     </tbody>
   );
-}
+});
 
 export const TableCell = memo(function TableCell({ children }: { children: React.ReactNode }) {
   return (

--- a/app/kube-knots/src/components/query-wrapper.tsx
+++ b/app/kube-knots/src/components/query-wrapper.tsx
@@ -1,10 +1,4 @@
-import { type PropsWithChildren } from "react";
-
-import { type useResourceList } from "../hooks/use-resource-list";
-
-interface QueryWrapperProps extends Required<PropsWithChildren> {
-  query: ReturnType<typeof useResourceList>;
-}
+import { memo, useCallback, type PropsWithChildren } from "react";
 
 interface WrapperContentProps {
   title: string;
@@ -12,7 +6,11 @@ interface WrapperContentProps {
   action?: JSX.Element;
 }
 
-function WrapperContent({ title, subtitle, action }: WrapperContentProps) {
+const WrapperContent = memo(function WrapperContent({
+  title,
+  subtitle,
+  action,
+}: WrapperContentProps) {
   return (
     <div className="p-8 text-center">
       <p className="text-base font-semibold dark:text-gray-400">{subtitle}</p>
@@ -20,23 +18,31 @@ function WrapperContent({ title, subtitle, action }: WrapperContentProps) {
       {action}
     </div>
   );
+});
+
+interface QueryWrapperProps extends Required<PropsWithChildren> {
+  queryIsLoading: boolean;
+  queryIsError: boolean;
+  queryIsSuccess: boolean;
+  queryError: unknown;
+  queryDataLength: number;
 }
 
-export function QueryWrapper({ query, children }: QueryWrapperProps) {
+export function QueryWrapper(props: QueryWrapperProps) {
   // TODO: improve the UI for these states
-  if (query.isLoading) {
+  if (props.queryIsLoading) {
     return <WrapperContent title="Loading..." subtitle="..." />;
   }
 
-  if (query.isError) {
+  if (props.queryIsError) {
     // TODO: update to account for linux and windows
-    const handleClick = () => {
+    const handleClick = useCallback(() => {
       location.reload();
-    };
+    }, []);
 
     return (
       <WrapperContent
-        title={JSON.stringify(query.error)}
+        title={JSON.stringify(props.queryError)}
         subtitle="Uh Oh"
         action={
           <button
@@ -50,9 +56,9 @@ export function QueryWrapper({ query, children }: QueryWrapperProps) {
     );
   }
 
-  if (query.isSuccess && query.data.items.length === 0) {
+  if (props.queryIsSuccess && props.queryDataLength === 0) {
     return <WrapperContent title="No resources found" subtitle="404" />;
   }
 
-  return <div>{children}</div>;
+  return <div>{props.children}</div>;
 }

--- a/app/kube-knots/src/components/resource-table.tsx
+++ b/app/kube-knots/src/components/resource-table.tsx
@@ -55,7 +55,13 @@ export function ResourceTable<T extends ResourceBase>({
   });
 
   return (
-    <QueryWrapper query={resourceListQuery}>
+    <QueryWrapper
+      queryIsSuccess={resourceListQuery.isSuccess}
+      queryIsLoading={resourceListQuery.isLoading}
+      queryIsError={resourceListQuery.isError}
+      queryError={resourceListQuery.error}
+      queryDataLength={resourceListQuery.data?.items.length || 0}
+    >
       <div className="flex justify-between">
         <PathnameTitle />
         <SearchInput onChange={handleSearch} value={search} />

--- a/app/kube-knots/src/layout.tsx
+++ b/app/kube-knots/src/layout.tsx
@@ -128,7 +128,13 @@ export function Layout({ children }: PropsWithChildren) {
         <main className="flex-1 select-none">
           <div className="mx-auto max-w-7xl">
             {namespaceQuery && (
-              <QueryWrapper query={namespaceQuery}>
+              <QueryWrapper
+                queryIsSuccess={namespaceQuery.isSuccess}
+                queryIsLoading={namespaceQuery.isLoading}
+                queryIsError={namespaceQuery.isError}
+                queryError={namespaceQuery.error}
+                queryDataLength={namespaceQuery.data?.items.length || 0}
+              >
                 <div className="p-4">{children}</div>
               </QueryWrapper>
             )}


### PR DESCRIPTION
## Description

currently, the `query` prop is always changing, so queryWrapper rerender as a result, this update will only passing in primitive props to queryWrapper so react can better optimize rendering. 

## Testing

<!-- Please describe the testing that was performed to validate these changes -->

## Screenshots

<!-- Please provide any relevant screenshots or visual aids to help reviewers understand the changes -->

## Related Issues

<!-- Please list any related issues or pull requests -->

## Additional Notes

<!-- Please provide any additional information that may be helpful, such as performance improvements, tradeoffs, or design decisions -->
