### PR TITLE
fix: fix missing jobName error when requesting job logs

### DIFF
--- a/app/kube-knots/src/components/pod-logs.tsx
+++ b/app/kube-knots/src/components/pod-logs.tsx
@@ -56,9 +56,7 @@ export function PodLogs({ isOpen, selected, handleClose }: PodLogsProps) {
         context: currentContext,
       };
 
-      const args = isPod(selected)
-        ? { container, podName: name }
-        : { jobName: selected?.metadata?.labels?.["job-name"] };
+      const args = isPod(selected) ? { container, podName: name } : { jobName: name };
 
       return invoke<string>(command, { ...sharedArgs, ...args });
     },


### PR DESCRIPTION
## Description

when the log is requested on the jobs page, we actually want pass the name of the job itself since the backend does the lookup for the pod name. 

## Testing

<!-- Please describe the testing that was performed to validate these changes -->

## Screenshots

<!-- Please provide any relevant screenshots or visual aids to help reviewers understand the changes -->

## Related Issues

<!-- Please list any related issues or pull requests -->

## Additional Notes

<!-- Please provide any additional information that may be helpful, such as performance improvements, tradeoffs, or design decisions -->
