### PR TITLE
fix: update editor to use 2 space tabs

### DIFF
--- a/app/kube-knots/src/components/resource-create-edit-drawer.tsx
+++ b/app/kube-knots/src/components/resource-create-edit-drawer.tsx
@@ -182,6 +182,7 @@ export function ResourceCreateEditDrawer<T extends { kind?: string; metadata?: V
           value={code}
           theme={editorTheme}
           onChange={(code) => setCode(code ?? "")}
+          options={{ tabSize: 2 }}
         />
       )}
     </Drawer>


### PR DESCRIPTION
## Description

this was causing a minor issue where the templates have 2 space tabs, but the editor defaults to 4. 

## Testing

<!-- Please describe the testing that was performed to validate these changes -->

## Screenshots

<!-- Please provide any relevant screenshots or visual aids to help reviewers understand the changes -->

## Related Issues

<!-- Please list any related issues or pull requests -->

## Additional Notes

<!-- Please provide any additional information that may be helpful, such as performance improvements, tradeoffs, or design decisions -->
